### PR TITLE
Make a better watch script because of manifest v3

### DIFF
--- a/bundle-script.js
+++ b/bundle-script.js
@@ -1,8 +1,7 @@
 import { exec } from "child_process";
 import { copy } from "fs-extra";
-import { copyFile, rm, writeFile } from "fs/promises";
+import { copyFile, rm, writeFile, appendFile, readFile} from "fs/promises";
 import process, { argv } from "process";
-import readline from "readline";
 import zipper from "zip-local";
 import { MANIFEST_CHROME, MANIFEST_FIREFOX } from "./manifest.js";
 
@@ -17,7 +16,7 @@ const runCommand = (command, yes) =>
     });
   });
 
-const bundle = async (manifest, bundleDirectory) => {
+const bundle = async (manifest, bundleDirectory, browserFunc) => {
   try {
     // Remove old bundle directory
     await rm(bundleDirectory, { recursive: true, force: true }); // requires node 14+
@@ -27,27 +26,11 @@ const bundle = async (manifest, bundleDirectory) => {
     const runBuildScript = (directory) => {
       return new Promise(async (resolve, reject) => {
         let intervalId;
-        let spinner = "\\";
-        const startBuilding = () => {
-          let P = ["\\", "|", "/", "-"];
-          intervalId = setInterval(() => {
-            process.stdout.clearLine();
-            process.stdout.cursorTo(0);
-            spinner = P[P.indexOf(spinner) + 1] || P[0];
-            process.stdout.write(
-              `${spinner}   Building popup and content scripts...`
-            );
-          }, 250);
-        };
-
-        startBuilding();
 
         try {
           await runCommand(`cd ./${directory} && yarn && yarn build`);
-          clearInterval(intervalId);
           resolve();
         } catch (error) {
-          clearInterval(intervalId);
           console.error(
             `Error running build script for ${directory}: ${error}`
           );
@@ -59,8 +42,6 @@ const bundle = async (manifest, bundleDirectory) => {
     await runBuildScript("popup");
     await runBuildScript("content-scripts");
 
-    process.stdout.clearLine();
-    process.stdout.cursorTo(0);
     console.log("🔥  Built popup and content scripts.");
 
     // Bundle popup Next.js export
@@ -94,6 +75,8 @@ const bundle = async (manifest, bundleDirectory) => {
       "utf8"
     );
 
+    await browserFunc(bundleDirectory);
+
     // Done.
     console.log(`📦  Bundled \`${bundleDirectory}\`.`);
 
@@ -117,47 +100,67 @@ const bundle = async (manifest, bundleDirectory) => {
 
 
 const processArguments = async () => {
-    if(process.argv.length != 3){
+    if(process.argv.length < 3){
       console.log("Error: didn't supply a build option...");
-      console.log("Usage: yarn bundle all | firefox | chrome | safari");
-      process.exit(1);
+      printUsageAndExit();
     }
     var option = process.argv[2].toLowerCase();
+    var debugMode = true;
+    if(process.argv.length > 4){
+      if(!(process.argv[3] === "release" || process.argv[3] === "debug")){
+        console.log("Error: 2nd argument should be either release or debug");
+        printUsageAndExit();
+      }
+      debugMode = argv[3] === "debug";
+    }
+
+    const firefoxDebug = async (bundleDirectory) => {
+      await appendFile(`${bundleDirectory}/background.js`, 
+        await (await readFile('dev/firefox/background.js')).toString()
+      );
+    };
     switch (option) {
       case "all":
       case "chrome":
-        await bundle(MANIFEST_CHROME, "bundle/chrome");
+        var manifest = MANIFEST_CHROME;
+        if(debugMode){
+          manifest.permissions = [...manifest.permissions,"offscreen", "tabs"];
+        }
+        await bundle(manifest, "bundle/chrome",
+        async (bundleDirectory) => {
+          await appendFile(`${bundleDirectory}/background.js`, 
+            await (await readFile('dev/chrome/background.js')).toString()
+          );
+          await copyFile('dev/chrome/watch.html', `${bundleDirectory}/watch.html`);
+          await copyFile('dev/chrome/watch.js', `${bundleDirectory}/watch.js`);
+
+        });
         if(option != "all") break;
 
       case "firefox":
-        await bundle(MANIFEST_FIREFOX, "bundle/firefox");
+        var manifest = MANIFEST_FIREFOX;
+        if(debugMode){
+          manifest.background.persistent = true;
+        }
+        await bundle(manifest, "bundle/firefox",firefoxDebug);
         if(option != "all") break;
 
       case "safari":
+        var manifest = MANIFEST_FIREFOX;
+        if(debugMode){
+          manifest.background.persistent = true;
+        }
         if(process.platform !== "darwin"){
           console.log("Skipping safari build since we are not on MacOS...");
           break;
         } 
-        await bundle(MANIFEST_FIREFOX, "bundle/firefox");
+        await bundle(manifest, "bundle/firefox",firefoxDebug);
 
-        let intervalId;
-        let spinner = "\\";
-        const startBuilding = () => {
-          let P = ["\\", "|", "/", "-"];
-          intervalId = setInterval(() => {
-            process.stdout.clearLine();
-            process.stdout.cursorTo(0);
-            spinner = P[P.indexOf(spinner) + 1] || P[0];
-            process.stdout.write(`${spinner}   Bundling Safari...`);
-          }, 250);
-        };
 
-        startBuilding();
         await runCommand(generateSafariProjectCommand, true);
         await runCommand(fixBundleIdentifierCommand, true);
 
 
-        clearInterval(intervalId);
         break;
     }
 };
@@ -172,3 +175,8 @@ const fixBundleIdentifierCommand = `find "bundle/safari/Sigarra Extension" \\( -
 
 
 await processArguments();
+
+function printUsageAndExit() {
+  console.log("Usage: yarn bundle all | firefox | chrome | safari <release|debug>");
+  process.exit(1);
+}

--- a/css/simpler.css
+++ b/css/simpler.css
@@ -18,5 +18,5 @@
 }
 
 #barralocalizacao {
-    display: none;
+  display: none;
 }

--- a/dev/chrome/background.js
+++ b/dev/chrome/background.js
@@ -1,0 +1,23 @@
+//messages from offscreen should be passed as {msg:"reload"}
+chrome.runtime.onMessage.addListener(async (object) => {
+    console.log("Received message... %s", object.msg);
+    if(object.msg === "reload"){
+    
+        var tabList = await chrome.tabs.query({url:"*://sigarra.up.pt/feup/*"});
+        for(var tab of tabList){
+            console.log("Reloading tab ID: %d", tab.id)
+            chrome.tabs.reload(tab.id);
+        }
+        chrome.runtime.reload();
+  }
+}
+);
+
+  
+chrome.offscreen.createDocument({
+    url: chrome.runtime.getURL('watch.html'),
+    reasons: ['WEB_RTC'],
+    justification: 'live reload the app'
+});
+  
+  

--- a/dev/chrome/watch.html
+++ b/dev/chrome/watch.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="./watch.js"></script>

--- a/dev/chrome/watch.js
+++ b/dev/chrome/watch.js
@@ -1,0 +1,9 @@
+const watchConn = new WebSocket("ws://127.0.0.1:8069");
+
+
+watchConn.addEventListener('message', (message) => {
+    if(message.data == "reload"){
+        chrome.runtime.sendMessage({msg:"reload"});
+    }
+});
+

--- a/dev/firefox/background.js
+++ b/dev/firefox/background.js
@@ -1,0 +1,10 @@
+const watchConn = new WebSocket("ws://127.0.0.1:8069");
+
+
+watchConn.addEventListener('message', (message) => {
+    if(message.data == "reload"){
+        chrome.runtime.reload();
+    }
+});
+console.log("pog");
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "build": "node ./bundle-script.js",
-    "bundle": "node ./bundle-script.js"
+    "bundle": "node ./bundle-script.js",
+    "watch": "node ./watch-script.js"
   },
   "dependencies": {
     "fs-extra": "^11.1.0",
@@ -11,6 +12,8 @@
     "zip-local": "^0.3.5"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.13"
+    "@types/fs-extra": "^9.0.13",
+    "watch": "^1.0.2",
+    "ws": "^8.12.1"
   }
 }

--- a/watch-script.js
+++ b/watch-script.js
@@ -1,0 +1,52 @@
+import { spawn } from "child_process";
+import { argv, exit, stderr } from "process";
+
+import watch from "watch";
+import { WebSocketServer } from "ws"
+
+
+const wss = new WebSocketServer({port: 8069});
+
+
+wss.on('connection', (stream) => {
+    console.log("A new client connected...");
+});
+
+if(argv.length != 3){
+    console.log("Error: didn't provide a target...");
+    console.log("Usage: yarn watch firefox|chrome|safari");
+    exit(1);
+}
+
+watch.watchTree(".", {
+    ignoreDotFiles:true, 
+    filter:(path, stat)=>{
+        //TODO (luisd): rewrite this lmao
+        return (path.includes("background.js") || 
+            path.includes("content-scripts") || 
+            path.includes("popup") ||
+            path.includes("css") ||
+            path.includes("images") ||
+            path.includes("dev"))
+            && !(path.includes("bundle") || path.includes('out') || path.includes('node_modules'));
+    }},
+    async (f, curr, prev)  => {
+        console.log("File %s changed... building bundle again...", f);
+        const command = spawn('yarn', ['bundle', argv[2]]);
+        command.stdout.on('data', (data) => {
+            console.log("Build stdout: %s", data);
+        })
+        command.stderr.on('data', (data) => {
+            console.log("Build stderr: %s", data);
+        })
+        command.on('exit', (code) => {
+            if(code == 0){
+                console.log("Reloading clients...");
+                wss.clients.forEach((client) => {
+                    client.send("reload");
+                })
+            }
+        })
+
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,13 @@ async@^1.4.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==
 
+exec-sh@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
+  integrity sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==
+  dependencies:
+    merge "^1.2.0"
+
 fs-extra@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.0.tgz#5784b102104433bb0e090f48bfc4a30742c357ed"
@@ -49,6 +56,16 @@ jszip@^2.6.1:
   dependencies:
     pako "~1.0.2"
 
+merge@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
+
+minimist@^1.2.0:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 node-cmd@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/node-cmd/-/node-cmd-5.0.0.tgz#a4a850b569e009bec0199a131c9db607144fdbc0"
@@ -68,6 +85,19 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+watch@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-1.0.2.tgz#340a717bde765726fa0aa07d721e0147a551df0c"
+  integrity sha512-1u+Z5n9Jc1E2c7qDO8SinPoZuHj7FgbgU1olSFoyaklduDvvtX7GMMtlE6OC9FTXq4KvNAOfj6Zu4vI1e9bAKA==
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
+
+ws@^8.12.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
 zip-local@^0.3.5:
   version "0.3.5"


### PR DESCRIPTION
This is a summary of changes needed to make hot reloading work:

- Change the build script to conditionally add files or changes to the manifest extension depending of building in "release" or "debug"
- Make a watch program that is also a WebSocket server to communicate with the extension, to reload it.
- On firefox the process is easier and requires just a manifest change.
- On Chrome, because of manifest v3, we need to make some big adjustments: we need to create a tab "offscreen" in order to maintain a WebSocket connection and communicate the results with the main service worker (which contains all power to do changes)

