### PR TITLE
Fixed chromium script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "build": "webpack",
         "watch": "webpack --watch",
         "run:firefox": "web-ext run --source-dir dist/firefox --start-url fe.up.pt --keep-profile-changes",
-        "run:chrome": "web-ext run --source-dir dist/chrome --chromium-binary --start-url fe.up.pt --keep-profile-changes",
+        "run:chrome": "web-ext run --source-dir dist/chrome --target=chromium --start-url fe.up.pt --keep-profile-changes",
         "run": "yarn run:firefox",
         "dev:firefox": "concurrently 'yarn watch' 'yarn run:firefox'",
         "dev:chrome": "concurrently 'yarn watch' 'yarn run:chrome'",


### PR DESCRIPTION
I was cloning the nitsig repo for me to check it out and try to help when I noticed that I couldn't debug on chrome because the script was launching firefox. I searched on google and found a solution. What do you think?